### PR TITLE
New board and moved config to platformio.ini

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,15 +1,15 @@
 # rf95modem
 This project provides a modem firmware for arduino boards with a rf95 compatible radio module and a serial interface such as the adafruit feather m0 lora device or the heltec oled lora 32 modules. 
 
-The current default config is for adafruit feather m0 lora device with 433 MHz.
+The current default config is for device with 433 MHz.
 
 ## Installation 
 
 The recommended way for building and installing the radio firmware is to have a working installation of platformio (http://platformio.org/) on your system.
 
-*IMPORTANT* Edit platformio.ini to add your target platform and configure the radio pins in main.cpp!
+*IMPORTANT* Edit platformio.ini to add your target platform and configure the radio pins in the build flags!
 
-Install on your device using `pio run -t upload`
+Install on your device using `pio run -t upload -e heltec_wifi_lora_32`
 
 ## Usage
 

--- a/platformio.ini
+++ b/platformio.ini
@@ -7,14 +7,23 @@
 ;
 ; Please visit documentation for the other options and examples
 ; http://docs.platformio.org/page/projectconf.html
+[platformio]
+env_default = adafruit_feather_m0
 
 [env:adafruit_feather_m0]
 platform = atmelsam
 board = adafruit_feather_m0
 framework = arduino
+build_flags = -DRFM95_CS=8 -DRFM95_RST=4 -DRFM95_INT=3 -DLED=13
 
-;[env:heltec_wifi_lora_32]
-;platform = espressif32
-;board = heltec_wifi_lora_32
-;framework = arduino
+[env:heltec_wifi_lora_32]
+platform = espressif32
+board = heltec_wifi_lora_32
+framework = arduino
+build_flags = -DRFM95_CS=18 -DRFM95_RST=14 -DRFM95_INT=26
 
+[env:adafruit_feather32u4]
+platform = atmelavr
+board = feather32u4
+framework = arduino
+build_flags = -DRFM95_CS=8 -DRFM95_RST=4 -DRFM95_INT=7 -DLED=13

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -5,25 +5,12 @@
 
 #define VERSION "0.1"
 
-// for feather m0
-#define RFM95_CS 8
-#define RFM95_RST 4
-#define RFM95_INT 3
-
-// for ttgo
-//#define RFM95_CS 18
-//#define RFM95_RST 14
-//#define RFM95_INT 26
-
 // Change to 434.0 or other frequency, must match RX's freq!
 //#define RF95_FREQ 868.0
 #define RF95_FREQ 434.0
 
 // Singleton instance of the radio driver
 RH_RF95 rf95(RFM95_CS, RFM95_INT);
-
-// RX indicator LED
-#define LED 13
 
 RH_RF95::ModemConfigChoice cur_modem_config = RH_RF95::Bw125Cr45Sf128;
 //RH_RF95::ModemConfigChoice cur_modem_config = RH_RF95::Bw125Cr48Sf4096;
@@ -32,7 +19,10 @@ byte rx_listen = 1;
 
 void setup()
 {
+  #ifdef LED
   pinMode(LED, OUTPUT);
+  #endif // LED
+
   pinMode(RFM95_RST, OUTPUT);
   digitalWrite(RFM95_RST, HIGH);
 
@@ -245,10 +235,16 @@ void loop()
 
     if (rf95.recv(buf, &len))
     {
+      #ifdef LED
       digitalWrite(LED, HIGH);
+      #endif // LED
+
       onpacketreceived(buf, len);
       delay(10);
+
+      #ifdef LED
       digitalWrite(LED, LOW);
+      #endif // LED
     }
     else
     {


### PR DESCRIPTION
This PR moves the `#define`-configuration from the `main.cpp` to the `platformio.ini`-file to ensure the usage of the right pins. Furthermore an `env` for the Adafruit Feather 32u4 was added.