### PR TITLE
Platformio.ini config file cleanup

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -1,54 +1,66 @@
-; PlatformIO Project Configuration File
-;
-;   Build options: build flags, source filter
-;   Upload options: custom upload port, speed and extra flags
-;   Library options: dependencies, extra library storages
-;   Advanced options: extra scripting
-;
-; Please visit documentation for the other options and examples
-; http://docs.platformio.org/page/projectconf.html
-
 [platformio]
-default_envs = adafruit_feather32u4
+default_envs = heltec_wifi_lora_32_display_ble
+
+[common]
+lib_deps = 124@1.89 ; RadioHead
+
+; define config for board Heltec WiFi LoRa 32 
+[heltec_wifi_lora_32]
+config_lora = -DRFM95_CS=18 -DRFM95_RST=14 -DRFM95_INT=26
+config_display = -DUSE_DISPLAY -DOLED_ADDRESS=0x3c -DOLED_SDA=4 -DOLED_SCL=15 -DOLED_RST=16
+config_ble = -DUSE_BLE
+libs_display = 
+    2978 ; ESP8266 and ESP32 Oled Driver for SSD1306 display
+    562 ; ESP8266_SSD1306
+libs_ble = 1841@1.0.1 ; ESP32 BLE Arduino
+
+; define config for board Adafruit Feather M0
+[adafruit_feather_m0]
+config_lora = -DRFM95_CS=8 -DRFM95_RST=4 -DRFM95_INT=7
+
+; define config for board Adafruit Feather 32u4
+[adafruit_feather32u4]
+config_lora = -DRFM95_CS=8 -DRFM95_RST=4 -DRFM95_INT=7 
+
 
 [env:heltec_wifi_lora_32]
 platform = espressif32
 board = heltec_wifi_lora_32
 framework = arduino
-lib_deps =  124@1.89
-build_flags = -fexceptions -DRFM95_CS=18 -DRFM95_RST=14 -DRFM95_INT=26
+build_flags = -fexceptions ${heltec_wifi_lora_32.config_lora}
+lib_deps =  ${common.lib_deps}
 
 [env:heltec_wifi_lora_32_display]
 platform = espressif32
 board = heltec_wifi_lora_32
 framework = arduino
-build_flags = -DRFM95_CS=18 -DRFM95_RST=14 -DRFM95_INT=26 -DUSE_DISPLAY -DOLED_ADDRESS=0x3c -DOLED_SDA=4 -DOLED_SCL=15 -DOLED_RST=16
-lib_deps = RadioHead, ESP8266 and ESP32 Oled Driver for SSD1306 display
+build_flags = -fexceptions ${heltec_wifi_lora_32.config_lora} ${heltec_wifi_lora_32.config_display}
+lib_deps = ${common.lib_deps} ${heltec_wifi_lora_32.libs_display}
 
 [env:heltec_wifi_lora_32_ble]
 platform = espressif32
 board = heltec_wifi_lora_32
 framework = arduino
-lib_deps =  1841@1.0.1, 124@1.89
-build_flags = -fexceptions -DRFM95_CS=18 -DRFM95_RST=14 -DRFM95_INT=26 -DUSE_BLE
+build_flags = -fexceptions ${heltec_wifi_lora_32.config_lora} ${heltec_wifi_lora_32.config_ble}
+lib_deps = ${common.lib_deps} ${heltec_wifi_lora_32.libs_ble}
 
 [env:heltec_wifi_lora_32_display_ble]
 platform = espressif32
 board = heltec_wifi_lora_32
 framework = arduino
-build_flags = -DRFM95_CS=18 -DRFM95_RST=14 -DRFM95_INT=26 -DUSE_DISPLAY -DOLED_ADDRESS=0x3c -DOLED_SDA=4 -DOLED_SCL=15 -DOLED_RST=16 -DUSE_BLE
-lib_deps = RadioHead, ESP8266 and ESP32 Oled Driver for SSD1306 display, 1841@1.0.1
+build_flags = -fexceptions ${heltec_wifi_lora_32.config_lora} ${heltec_wifi_lora_32.config_display} ${heltec_wifi_lora_32.config_ble} 
+lib_deps = ${common.lib_deps} ${heltec_wifi_lora_32.libs_display} ${heltec_wifi_lora_32.libs_ble}
 
 [env:adafruit_feather_m0]
 platform = atmelsam
 board = adafruit_feather_m0
 framework = arduino
-build_flags = -DRFM95_CS=8 -DRFM95_RST=4 -DRFM95_INT=3 -DLED=13
-lib_deps = RadioHead
+build_flags =  -DLED=13 ${adafruit_feather_m0.config_lora}
+lib_deps = ${common.lib_deps}
 
 [env:adafruit_feather32u4]
 platform = atmelavr
 board = feather32u4
 framework = arduino
-build_flags = -DRFM95_CS=8 -DRFM95_RST=4 -DRFM95_INT=7 -DLED=13
-lib_deps = RadioHead
+build_flags = -DLED=13 ${adafruit_feather32u4.config_lora}
+lib_deps = ${common.lib_deps}


### PR DESCRIPTION
- fixed missing dependency (ESP8266_SSD1306) for Heltec board
- based lib_deps on ids rather than on strings
- extracted common libraries
- extracted hardware configuration to board definition

The idea behind the changes is, to make it more transparent which libraries are used and to prevent multiple references of a library (easier maintainability).