### PR TITLE
Added new RadioHead modem mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,8 @@ AT+MODE=<NUM>       Set modem config:
                      Bw = 31.25 kHz, Cr = 4/8, Sf = 512chips/symbol, CRC on.
                     3 - slow+long range
                      Bw = 125 kHz, Cr = 4/8, Sf = 4096chips/symbol, CRC on.
+                    4 - slow+long range
+                     Bw = 125 kHz, Cr = 4/5, Sf = 2048chips/symbol, CRC on.
 ```
 
 ### Configuring the Modem

--- a/src/modem.cpp
+++ b/src/modem.cpp
@@ -340,6 +340,8 @@ void handle_command(String input)
         out_println("                     Bw = 31.25 kHz, Cr = 4/8, Sf = 512chips/symbol, CRC on.");
         out_println("                    " + String(RH_RF95::Bw125Cr48Sf4096) + " - slow+long range");
         out_println("                     Bw = 125 kHz, Cr = 4/8, Sf = 4096chips/symbol, CRC on.");
+        out_println("                    " + String(RH_RF95::Bw125Cr45Sf2048) + " - slow+long range");
+        out_println("                     Bw = 125 kHz, Cr = 4/5, Sf = 2048chips/symbol, CRC on.");
         out_println("+OK");
     }
     else if (input.startsWith("AT+INFO"))


### PR DESCRIPTION
Newer versions of RadioHead support a fifth modem mode, namely:

```
4 - slow+long range
Bw = 125 kHz, Cr = 4/5, Sf = 2048chips/symbol, CRC on.
```
