### PR TITLE
Restructured platformio.ini file for less redundancy

### DIFF
--- a/platformio.ini
+++ b/platformio.ini
@@ -1,41 +1,38 @@
 [platformio]
 default_envs = heltec_wifi_lora_32_display_ble_wifi
 
-[common]
+[env]
 lib_deps = 
     124@~1.113 ; RadioHead
-
-; define config for board Heltec WiFi LoRa 32 
-[heltec_wifi_lora_32]
-config_lora = -DRFM95_CS=18 -DRFM95_RST=14 -DRFM95_INT=26
 config_wifi = -DUSE_WIFI -DWIFI_SSID=\"rf95modem\" -DWIFI_PSK=\"rf95modemwifi\"
-config_display = -DUSE_DISPLAY -DOLED_ADDRESS=0x3c -DOLED_SDA=4 -DOLED_SCL=15 -DOLED_RST=16
 config_ble = -DUSE_BLE
 libs_display = 
     2978@~4.1.0 ; thingpulse/ESP8266 and ESP32 OLED driver for SSD1306 displays
 libs_ble = 
     1841@~1.0.1 ; ESP32 BLE Arduino
+libs_gps = 
+    1655@~1.0.2 ; TinyGPSPlus
+    6657@~1.1.0 ; AXP202X_Library
+
+; ================== BOARD PINOUTS ================== 
+; Heltec WiFi LoRa 32 
+[heltec_wifi_lora_32]
+config_lora = -DRFM95_CS=18 -DRFM95_RST=14 -DRFM95_INT=26
+config_display = -DUSE_DISPLAY -DOLED_ADDRESS=0x3c -DOLED_SDA=4 -DOLED_SCL=15 -DOLED_RST=16
 
 [heltec_t_beam_v10]
 config_lora = -DRFM95_CS=18 -DRFM95_RST=23 -DRFM95_INT=26
 config_gps = -DUSE_GPS -DGPS_RX_PIN=34 -DGPS_TX_PIN=12
-libs_gps = 
-    1655@~1.0.2 ; TinyGPSPlus
-    6657@~1.1.0 ; AXP202X_Library
 
 [heltec_t_beam_v07]
 config_lora = -DRFM95_CS=18 -DRFM95_RST=23 -DRFM95_INT=26
 config_gps = -DUSE_GPS -DGPS_RX_PIN=12 -DGPS_TX_PIN=15
-libs_gps = 
-    1655@~1.0.2 ; TinyGPSPlus
-    6657@~1.1.0 ; AXP202X_Library
 
-
-; define config for board Adafruit Feather M0
+; Adafruit Feather M0
 [adafruit_feather_m0]
 config_lora = -DRFM95_CS=8 -DRFM95_RST=4 -DRFM95_INT=7
 
-; define config for board Adafruit Feather 32u4
+; Adafruit Feather 32u4
 [adafruit_feather32u4]
 config_lora = -DRFM95_CS=8 -DRFM95_RST=4 -DRFM95_INT=7 
 
@@ -46,90 +43,88 @@ platform = espressif32
 board = heltec_wifi_lora_32
 framework = arduino
 build_flags = -fexceptions ${heltec_wifi_lora_32.config_lora}
-lib_deps =  ${common.lib_deps}
+lib_deps =  ${env.lib_deps}
 
 [env:heltec_wifi_lora_32_wifi]
 platform = espressif32
 board = heltec_wifi_lora_32
 framework = arduino
-build_flags = -fexceptions ${heltec_wifi_lora_32.config_lora} ${heltec_wifi_lora_32.config_wifi}
-lib_deps =  ${common.lib_deps}
-
+build_flags = -fexceptions ${heltec_wifi_lora_32.config_lora} ${env.config_wifi}
+lib_deps =  ${env.lib_deps}
 
 [env:heltec_wifi_lora_32_display]
 platform = espressif32
 board = heltec_wifi_lora_32
 framework = arduino
 build_flags = -fexceptions ${heltec_wifi_lora_32.config_lora} ${heltec_wifi_lora_32.config_display}
-lib_deps = ${common.lib_deps} ${heltec_wifi_lora_32.libs_display}
+lib_deps = ${env.lib_deps} ${env.libs_display}
 
 [env:heltec_wifi_lora_32_display_wifi]
 platform = espressif32
 board = heltec_wifi_lora_32
 framework = arduino
-build_flags = -fexceptions ${heltec_wifi_lora_32.config_lora} ${heltec_wifi_lora_32.config_display} ${heltec_wifi_lora_32.config_wifi}
-lib_deps = ${common.lib_deps} ${heltec_wifi_lora_32.libs_display}
+build_flags = -fexceptions ${heltec_wifi_lora_32.config_lora} ${heltec_wifi_lora_32.config_display} ${env.config_wifi}
+lib_deps = ${env.lib_deps} ${env.libs_display}
 
 [env:heltec_wifi_lora_32_ble]
 platform = espressif32
 board = heltec_wifi_lora_32
 framework = arduino
-build_flags = -fexceptions ${heltec_wifi_lora_32.config_lora} ${heltec_wifi_lora_32.config_ble}
-lib_deps = ${common.lib_deps} ${heltec_wifi_lora_32.libs_ble}
+build_flags = -fexceptions ${heltec_wifi_lora_32.config_lora} ${env.config_ble}
+lib_deps = ${env.lib_deps} ${env.libs_ble}
 
 [env:heltec_wifi_lora_32_ble_wifi]
 platform = espressif32
 board = heltec_wifi_lora_32
 framework = arduino
-build_flags = -fexceptions ${heltec_wifi_lora_32.config_lora} ${heltec_wifi_lora_32.config_ble} ${heltec_wifi_lora_32.config_wifi}
-lib_deps = ${common.lib_deps} ${heltec_wifi_lora_32.libs_ble}
+build_flags = -fexceptions ${heltec_wifi_lora_32.config_lora} ${env.config_ble} ${env.config_wifi}
+lib_deps = ${env.lib_deps} ${env.libs_ble}
 board_build.partitions = no_ota.csv
 
 [env:heltec_wifi_lora_32_display_ble]
 platform = espressif32
 board = heltec_wifi_lora_32
 framework = arduino
-build_flags = -fexceptions ${heltec_wifi_lora_32.config_lora} ${heltec_wifi_lora_32.config_display} ${heltec_wifi_lora_32.config_ble} 
-lib_deps = ${common.lib_deps} ${heltec_wifi_lora_32.libs_display} ${heltec_wifi_lora_32.libs_ble}
+build_flags = -fexceptions ${heltec_wifi_lora_32.config_lora} ${heltec_wifi_lora_32.config_display} ${env.config_ble} 
+lib_deps = ${env.lib_deps} ${env.libs_display} ${env.libs_ble}
 
 [env:heltec_wifi_lora_32_display_ble_wifi]
 platform = espressif32
 board = heltec_wifi_lora_32
 framework = arduino
-build_flags = -fexceptions ${heltec_wifi_lora_32.config_lora} ${heltec_wifi_lora_32.config_display} ${heltec_wifi_lora_32.config_ble} ${heltec_wifi_lora_32.config_wifi}
-lib_deps = ${common.lib_deps} ${heltec_wifi_lora_32.libs_display} ${heltec_wifi_lora_32.libs_ble}
+build_flags = -fexceptions ${heltec_wifi_lora_32.config_lora} ${heltec_wifi_lora_32.config_display} ${env.config_ble} ${env.config_wifi}
+lib_deps = ${env.lib_deps} ${env.libs_display} ${env.libs_ble}
 board_build.partitions = no_ota.csv
 
 
 ; ================== T-BEAM ================== 
-
 [env:t_beam_v10]
 platform = espressif32
 board = heltec_wifi_lora_32
 framework = arduino
 build_flags = -fexceptions ${heltec_t_beam_v10.config_lora} ${heltec_t_beam_v10.config_gps}
-lib_deps =  ${common.lib_deps} ${heltec_t_beam_v10.libs_gps}
+lib_deps =  ${env.lib_deps} ${env.libs_gps}
 
 [env:t_beam_v10_ble]
 platform = espressif32
 board = heltec_wifi_lora_32
 framework = arduino
-build_flags = -fexceptions ${heltec_t_beam_v10.config_lora} ${heltec_t_beam_v10.config_gps} ${heltec_wifi_lora_32.config_ble} 
-lib_deps =  ${common.lib_deps} ${heltec_t_beam_v10.libs_gps} ${heltec_wifi_lora_32.libs_ble} 
+build_flags = -fexceptions ${heltec_t_beam_v10.config_lora} ${heltec_t_beam_v10.config_gps} ${env.config_ble} 
+lib_deps =  ${env.lib_deps} ${env.libs_gps} ${env.libs_ble} 
 
 [env:t_beam_v10_wifi]
 platform = espressif32
 board = heltec_wifi_lora_32
 framework = arduino
-build_flags = -fexceptions ${heltec_t_beam_v10.config_lora} ${heltec_t_beam_v10.config_gps} ${heltec_wifi_lora_32.config_ble} ${heltec_wifi_lora_32.config_wifi} 
-lib_deps =  ${common.lib_deps} ${heltec_t_beam_v10.libs_gps} ${heltec_wifi_lora_32.libs_ble} 
+build_flags = -fexceptions ${heltec_t_beam_v10.config_lora} ${heltec_t_beam_v10.config_gps} ${env.config_wifi} 
+lib_deps =  ${env.lib_deps} ${env.libs_gps} ${env.libs_ble} 
 
 [env:t_beam_v10_ble_wifi]
 platform = espressif32
 board = heltec_wifi_lora_32
 framework = arduino
-build_flags = -fexceptions ${heltec_t_beam_v10.config_lora} ${heltec_t_beam_v10.config_gps} ${heltec_wifi_lora_32.config_ble} ${heltec_wifi_lora_32.config_wifi} 
-lib_deps =  ${common.lib_deps} ${heltec_t_beam_v10.libs_gps} ${heltec_wifi_lora_32.libs_ble} 
+build_flags = -fexceptions ${heltec_t_beam_v10.config_lora} ${heltec_t_beam_v10.config_gps} ${env.config_ble} ${env.config_wifi} 
+lib_deps =  ${env.lib_deps} ${env.libs_gps} ${env.libs_ble} 
 board_build.partitions = no_ota.csv
 
 [env:t_beam_v07]
@@ -137,42 +132,42 @@ platform = espressif32
 board = heltec_wifi_lora_32
 framework = arduino
 build_flags = -fexceptions ${heltec_t_beam_v07.config_lora} ${heltec_t_beam_v07.config_gps}
-lib_deps =  ${common.lib_deps} ${heltec_t_beam_v07.libs_gps}
+lib_deps =  ${env.lib_deps} ${env.libs_gps}
 
 [env:t_beam_v07_ble]
 platform = espressif32
 board = heltec_wifi_lora_32
 framework = arduino
-build_flags = -fexceptions ${heltec_t_beam_v07.config_lora} ${heltec_t_beam_v07.config_gps} ${heltec_wifi_lora_32.config_ble} 
-lib_deps =  ${common.lib_deps} ${heltec_t_beam_v07.libs_gps} ${heltec_wifi_lora_32.libs_ble} 
+build_flags = -fexceptions ${heltec_t_beam_v07.config_lora} ${heltec_t_beam_v07.config_gps} ${env.config_ble} 
+lib_deps =  ${env.lib_deps} ${env.libs_gps} ${env.libs_ble} 
 
 [env:t_beam_v07_wifi]
 platform = espressif32
 board = heltec_wifi_lora_32
 framework = arduino
-build_flags = -fexceptions ${heltec_t_beam_v07.config_lora} ${heltec_t_beam_v07.config_gps} ${heltec_wifi_lora_32.config_ble} ${heltec_wifi_lora_32.config_wifi} 
-lib_deps =  ${common.lib_deps} ${heltec_t_beam_v07.libs_gps} ${heltec_wifi_lora_32.libs_ble} 
+build_flags = -fexceptions ${heltec_t_beam_v07.config_lora} ${heltec_t_beam_v07.config_gps} ${env.config_wifi} 
+lib_deps =  ${env.lib_deps} ${env.libs_gps} ${env.libs_ble} 
 
 [env:t_beam_v07_ble_wifi]
 platform = espressif32
 board = heltec_wifi_lora_32
 framework = arduino
-build_flags = -fexceptions ${heltec_t_beam_v07.config_lora} ${heltec_t_beam_v07.config_gps} ${heltec_wifi_lora_32.config_ble} ${heltec_wifi_lora_32.config_wifi} 
-lib_deps =  ${common.lib_deps} ${heltec_t_beam_v07.libs_gps} ${heltec_wifi_lora_32.libs_ble} 
+build_flags = -fexceptions ${heltec_t_beam_v07.config_lora} ${heltec_t_beam_v07.config_gps} ${env.config_ble} ${env.config_wifi} 
+lib_deps =  ${env.lib_deps} ${env.libs_gps} ${env.libs_ble} 
 board_build.partitions = no_ota.csv
 
-; ================== ADAFRUIT ================== 
 
+; ================== ADAFRUIT ================== 
 [env:adafruit_feather_m0]
 platform = atmelsam
 board = adafruit_feather_m0
 framework = arduino
 build_flags =  -DLED=13 ${adafruit_feather_m0.config_lora}
-lib_deps = ${common.lib_deps}
+lib_deps = ${env.lib_deps}
 
 [env:adafruit_feather32u4]
 platform = atmelavr
 board = feather32u4
 framework = arduino
 build_flags = -DLED=13 ${adafruit_feather32u4.config_lora}
-lib_deps = ${common.lib_deps}
+lib_deps = ${env.lib_deps}


### PR DESCRIPTION
The `[common]` section was renamed to `[env]`, as this is the proposed [name of PlatformIO](https://docs.platformio.org/en/latest/projectconf/section_env.html#common-env) for common properties.

As rf95modem supports only one GPS library, and WiFi and BLE configs are common as well (and were referenced from other platforms beforehand), those have been moved to the `[env]` section as well.