### PR TITLE
fix: PlatformIO build

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -37,4 +37,4 @@ jobs:
         python -m pip install --upgrade pip
         pip install --upgrade platformio
     - name: Run PlatformIO
-      run: pio run -e heltec_wifi_lora_32_display_ble_wifi -e t_beam_v10_ble_wifi -e adafruit_feather_m0 -e adafruit_feather32u4
+      run: pio run

--- a/platformio.ini
+++ b/platformio.ini
@@ -1,19 +1,14 @@
-[platformio]
-default_envs = heltec_wifi_lora_32_display_ble_wifi
-
 [env]
 monitor_speed = 115200
 lib_deps = 
-    124@~1.113 ; RadioHead
+    mikem/RadioHead@^1.120
 config_wifi = -DUSE_WIFI -DWIFI_SSID=\"rf95modem\" -DWIFI_PSK=\"rf95modemwifi\"
 config_ble = -DUSE_BLE
 libs_display = 
-    2978@~4.1.0 ; thingpulse/ESP8266 and ESP32 OLED driver for SSD1306 displays
-libs_ble = 
-    1841@~1.0.1 ; ESP32 BLE Arduino
+    thingpulse/ESP8266 and ESP32 OLED driver for SSD1306 displays@^4.4.0
 libs_gps = 
-    1655@~1.0.2 ; TinyGPSPlus
-    6657@~1.1.0 ; AXP202X_Library
+    mikalhart/TinyGPSPlus@^1.0.3
+    lewisxhe/AXP202X_Library@^1.1.3
 
 ; ================== BOARD PINOUTS ================== 
 ; Heltec WiFi LoRa 32 
@@ -77,14 +72,14 @@ platform = espressif32
 board = heltec_wifi_lora_32
 framework = arduino
 build_flags = -fexceptions ${heltec_wifi_lora_32.config_lora} ${env.config_ble}
-lib_deps = ${env.lib_deps} ${env.libs_ble}
+lib_deps = ${env.lib_deps}
 
 [env:heltec_wifi_lora_32_ble_wifi]
 platform = espressif32
 board = heltec_wifi_lora_32
 framework = arduino
 build_flags = -fexceptions ${heltec_wifi_lora_32.config_lora} ${env.config_ble} ${env.config_wifi}
-lib_deps = ${env.lib_deps} ${env.libs_ble}
+lib_deps = ${env.lib_deps}
 board_build.partitions = no_ota.csv
 
 [env:heltec_wifi_lora_32_display_ble]
@@ -92,14 +87,14 @@ platform = espressif32
 board = heltec_wifi_lora_32
 framework = arduino
 build_flags = -fexceptions ${heltec_wifi_lora_32.config_lora} ${heltec_wifi_lora_32.config_display} ${env.config_ble} 
-lib_deps = ${env.lib_deps} ${env.libs_display} ${env.libs_ble}
+lib_deps = ${env.lib_deps} ${env.libs_display}
 
 [env:heltec_wifi_lora_32_display_ble_wifi]
 platform = espressif32
 board = heltec_wifi_lora_32
 framework = arduino
 build_flags = -fexceptions ${heltec_wifi_lora_32.config_lora} ${heltec_wifi_lora_32.config_display} ${env.config_ble} ${env.config_wifi}
-lib_deps = ${env.lib_deps} ${env.libs_display} ${env.libs_ble}
+lib_deps = ${env.lib_deps} ${env.libs_display}
 board_build.partitions = no_ota.csv
 
 
@@ -116,21 +111,21 @@ platform = espressif32
 board = heltec_wifi_lora_32
 framework = arduino
 build_flags = -fexceptions ${heltec_t_beam_v10.config_lora} ${heltec_t_beam_v10.config_gps} ${env.config_ble} 
-lib_deps =  ${env.lib_deps} ${env.libs_gps} ${env.libs_ble} 
+lib_deps =  ${env.lib_deps} ${env.libs_gps}
 
 [env:t_beam_v10_wifi]
 platform = espressif32
 board = heltec_wifi_lora_32
 framework = arduino
 build_flags = -fexceptions ${heltec_t_beam_v10.config_lora} ${heltec_t_beam_v10.config_gps} ${env.config_wifi} 
-lib_deps =  ${env.lib_deps} ${env.libs_gps} ${env.libs_ble} 
+lib_deps =  ${env.lib_deps} ${env.libs_gps}
 
 [env:t_beam_v10_ble_wifi]
 platform = espressif32
 board = heltec_wifi_lora_32
 framework = arduino
 build_flags = -fexceptions ${heltec_t_beam_v10.config_lora} ${heltec_t_beam_v10.config_gps} ${env.config_ble} ${env.config_wifi} 
-lib_deps =  ${env.lib_deps} ${env.libs_gps} ${env.libs_ble} 
+lib_deps =  ${env.lib_deps} ${env.libs_gps}
 board_build.partitions = no_ota.csv
 
 [env:t_beam_v07]
@@ -145,21 +140,21 @@ platform = espressif32
 board = heltec_wifi_lora_32
 framework = arduino
 build_flags = -fexceptions ${heltec_t_beam_v07.config_lora} ${heltec_t_beam_v07.config_gps} ${env.config_ble} 
-lib_deps =  ${env.lib_deps} ${env.libs_gps} ${env.libs_ble} 
+lib_deps =  ${env.lib_deps} ${env.libs_gps}
 
 [env:t_beam_v07_wifi]
 platform = espressif32
 board = heltec_wifi_lora_32
 framework = arduino
 build_flags = -fexceptions ${heltec_t_beam_v07.config_lora} ${heltec_t_beam_v07.config_gps} ${env.config_wifi} 
-lib_deps =  ${env.lib_deps} ${env.libs_gps} ${env.libs_ble} 
+lib_deps =  ${env.lib_deps} ${env.libs_gps}
 
 [env:t_beam_v07_ble_wifi]
 platform = espressif32
 board = heltec_wifi_lora_32
 framework = arduino
 build_flags = -fexceptions ${heltec_t_beam_v07.config_lora} ${heltec_t_beam_v07.config_gps} ${env.config_ble} ${env.config_wifi} 
-lib_deps =  ${env.lib_deps} ${env.libs_gps} ${env.libs_ble} 
+lib_deps =  ${env.lib_deps} ${env.libs_gps}
 board_build.partitions = no_ota.csv
 
 
@@ -176,7 +171,7 @@ platform = espressif32
 board = ttgo-lora32-v2
 framework = arduino
 build_flags = -fexceptions ${ttgo_t_fox.config_display} ${ttgo_t_fox.config_lora} ${env.config_ble}
-lib_deps = ${env.lib_deps} ${env.libs_display} ${env.libs_ble}
+lib_deps = ${env.lib_deps} ${env.libs_display}
 
 [env:ttgo_t_fox_display_wifi]
 platform = espressif32
@@ -190,7 +185,7 @@ platform = espressif32
 board = ttgo-lora32-v2
 framework = arduino
 build_flags = -fexceptions ${ttgo_t_fox.config_display} ${ttgo_t_fox.config_lora} ${env.config_ble} ${env.config_wifi} 
-lib_deps = ${env.lib_deps} ${env.libs_display} ${env.libs_ble}
+lib_deps = ${env.lib_deps} ${env.libs_display}
 board_build.partitions = no_ota.csv
 
 


### PR DESCRIPTION
- Remove conflicting ESP32 BLE Arduino library for BLE as it became merged into upstream Arduino ESP32[0].
- Refer to library dependencies by their project name, as PlatformIO requires now.
- Bump dependencies.
- Remove default environment to build all targets by default. This ensures at least compile time stability.
- Build all environments in the GitHub Action CI.

[0] https://github.com/nkolban/ESP32_BLE_Arduino/commit/adc2aee2f0d01eb6b30dd5ad3589f2cc89934beb